### PR TITLE
Git clone + fetch instead of init + fetch.

### DIFF
--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -89,7 +89,7 @@ module Pod
         end
 
         Dir.chdir(target_path) do
-          if not use_cache? do
+          if !use_cache?
             git! "init"
             git! "remote add origin '#{clone_url}'"
           end


### PR DESCRIPTION
Init + fetch is 6x slower than clone + fetch for large projects. Discussion at CocoaPods/CocoaPods#1077.
