### PR TITLE
Add :checkout option to allow checkinable svn pod when combined with --no-clean

### DIFF
--- a/lib/cocoapods-downloader/subversion.rb
+++ b/lib/cocoapods-downloader/subversion.rb
@@ -3,7 +3,7 @@ module Pod
     class Subversion < Base
 
       def self.options
-        [:revision, :tag, :folder]
+        [:revision, :tag, :folder, :checkout]
       end
 
       def options_specific?
@@ -23,7 +23,8 @@ module Pod
       executable :svn
 
       def download!
-        output = svn!(%|#{export_subcommand} "#{reference_url}" "#{target_path}"|)
+          subcommand = options[:checkout] ? checkout_subcommand : export_subcommand
+          output = svn!(%|#{subcommand} "#{reference_url}" "#{target_path}"|)
           store_exported_revision(output)
       end
 
@@ -39,6 +40,10 @@ module Pod
 
       def export_subcommand
         result = 'export --non-interactive --trust-server-cert --force'
+      end
+
+      def checkout_subcommand
+        result = 'checkout --non-interactive --trust-server-cert --force'
       end
 
       def reference_url


### PR DESCRIPTION
The svn downloader uses export instead of checkout since
https://github.com/CocoaPods/CocoaPods/pull/473.

But having a "checkin-able" pod is still usefull for some Pods developpers even
if it has been aggreed to be a minority-use case.
(from https://github.com/CocoaPods/CocoaPods/issues/245 discussion).

Currently with Git, it is just by using `--no-clean` to `pod install` or `pod update`.
With this options, SVN can also have this feature.
