### PR TITLE
Adding optional support of --depth for github only.

### DIFF
--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -60,7 +60,11 @@ module Pod
           command = ['clone', url.shellescape, target_path.shellescape]
 
           unless options[:commit]
-            command += ['--single-branch', '--depth 1']
+            command << '--single-branch'
+
+            if supports_depth?
+              command << '--depth 1'
+            end
           end
 
           unless force_head
@@ -85,8 +89,27 @@ module Pod
       #
       def init_submodules
         Dir.chdir(target_path) do
-          git! 'submodule update --init --depth 1'
+          command = 'submodule update --init'
+
+          if supports_depth?
+             command += ' --depth 1'
+          end
+
+          git! command
         end
+      end
+
+      # Does git server support '--depth' parameter?
+      #
+      def supports_depth?
+        is_github?
+      end
+
+      # Is the URI pointing to github.com?
+      #
+      def is_github?
+        require 'uri'
+        URI(url.to_s).host == 'github.com'
       end
     end
   end


### PR DESCRIPTION
Hey guys, 

here's my implementation of detection of --depth support.

Related issue: https://github.com/CocoaPods/CocoaPods/issues/2481

For now it's only detected by URL github host name. If it's not github.com we don't allow usage of --depth param.

I didn't know how to fix the tests. I would appreciate someone from the project to help me out write those.

Thank you, Ladislav
