### PR TITLE
Checkout submodules recursively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp/
 coverage/
 spec/fixtures/git-repo
 spec/fixtures/git-submodule-repo
+spec/fixtures/mercurial-repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Checkout git submodules recursively.  
   [Boris Bügling](https://github.com/neonichu)
+  [Samuel Giddins](https://github.com/segiddins)
   [#46](https://github.com/CocoaPods/cocoapods-downloader/pull/46)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Master
+
+##### Bug Fixes
+
+* Checkout git submodules recursively.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#46](https://github.com/CocoaPods/cocoapods-downloader/pull/46)
+
+
 ## 0.9.1
 
 ##### Enhancements

--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -109,11 +109,11 @@ module Pod
         end
       end
 
-      # Initializes and updates the submodules of the cloned repo.
+      # Initializes and updates the submodules of the cloned repo recursively.
       #
       def init_submodules
         Dir.chdir(target_path) do
-          git! %w(submodule update --init)
+          git! %w(submodule update --init --recursive)
         end
       end
     end

--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -28,7 +28,6 @@ module Pod
       def download!
         clone
         checkout_commit if options[:commit]
-        init_submodules if options[:submodules]
       end
 
       # @return [void] Checks out the HEAD of the git source in the destination
@@ -36,7 +35,6 @@ module Pod
       #
       def download_head!
         clone(true)
-        init_submodules if options[:submodules]
       end
 
       # @!group Download implementations
@@ -98,6 +96,8 @@ module Pod
           end
         end
 
+        command << '--recursive' if options[:submodules]
+
         command
       end
 
@@ -106,14 +106,6 @@ module Pod
       def checkout_commit
         Dir.chdir(target_path) do
           git! 'checkout', '--quiet', options[:commit]
-        end
-      end
-
-      # Initializes and updates the submodules of the cloned repo recursively.
-      #
-      def init_submodules
-        Dir.chdir(target_path) do
-          git! %w(submodule update --init --recursive)
         end
       end
     end


### PR DESCRIPTION
We should checkout submodules recursively if the `submodule` option is `true`.