### PR TITLE
Use curl's --netrc-optional option instead of --netrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ##### Enhancements
 
-* None.  
+* When downloading via `HTTP`, `curl` won't force users from having a
+  `~/.netrc` file set up on their machine when the remote server requires
+  authentication.
+  [Sylvain Guillopé](https://github.com/sguillope)
+  [#55](https://github.com/CocoaPods/cocoapods-downloader/issues/55)
+  [CocoaPods#5318](https://github.com/CocoaPods/CocoaPods/issues/5318)
+  
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-downloader/http.rb
+++ b/lib/cocoapods-downloader/http.rb
@@ -90,7 +90,7 @@ module Pod
       end
 
       def download_file(full_filename)
-        curl! '-f', '-L', '-o', full_filename, url, '--create-dirs', '--netrc'
+        curl! '-f', '-L', '-o', full_filename, url, '--create-dirs', '--netrc-optional'
       end
 
       def extract_with_type(full_filename, type = :zip)


### PR DESCRIPTION
Using --netrc forces the user to provide authentication credentials through a
.netrc file in the user's home folder if the remote server requires
authentication.

However a user may want to provide the credentials right in the url which has
the advantage of not being dependent on having build machines set up with the
.netrc file. In an enterprise environment - potentially using many build
machines and having many team members - it can become a hassle to ensure proper
configuration of all build environments.

Ideally we should be able to specify the path to the .netrc file using the
--netrc-file option but that's for another time.

gh-55