### PR TITLE
Allow download strategies to preprocess download options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
   [CocoaPods#5318](https://github.com/CocoaPods/CocoaPods/issues/5318)
 
 * Allow download strategies to preprocess download options. This is used by
-  `git` strategy to resolve branches into commits directly.
+  `git` strategy to resolve branches into commits directly.  
   [Juan Civile](https://github.com/champo)
-  [Cocoapods#5386](https://github.com/CocoaPods/CocoaPods/pull/5386)
+  [CocoaPods#5386](https://github.com/CocoaPods/CocoaPods/pull/5386)
 
 
 ##### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ##### Enhancements
 
-* None.  
+* Allow download strategies to preprocess download options. This is used by
+  `git` strategy to resolve branches into commits directly.
+  [Juan Civile](https://github.com/champo)
+  [Cocoapods#5386](https://github.com/CocoaPods/CocoaPods/pull/5386)
 
 ##### Bug Fixes
 

--- a/README.markdown
+++ b/README.markdown
@@ -19,6 +19,7 @@ require 'cocoapods-downloader'
 
 target_path = './Downloads/MyDownload'
 options = { :git => 'example.com' }
+options = Pod::Downloader.preprocess_options(options)
 downloader = Pod::Downloader.for_target(target_path, options)
 downloader.cache_root = '~/Library/Caches/APPNAME'
 downloader.max_cache_size = 500

--- a/lib/cocoapods-downloader.rb
+++ b/lib/cocoapods-downloader.rb
@@ -69,5 +69,29 @@ module Pod
       klass = downloader_class_by_key[strategy]
       klass.new(target_path, url, sub_options)
     end
+
+    # Have the concrete strategy preprocess options
+    #
+    # @param [Hash<Symbol,String>] options
+    #        The request options to preprocess
+    #
+    # @return [Hash<Symbol,String>] the new options
+    #
+    def self.preprocess_options(options)
+      options = Hash[options.map { |k, v| [k.to_sym, v] }]
+
+      if options.nil? || options.empty?
+        raise DownloaderError, 'No source URL provided.'
+      end
+
+      strategy = strategy_from_options(options)
+      unless strategy
+        raise DownloaderError, 'Unsupported download strategy ' \
+          "`#{options.inspect}`."
+      end
+
+      klass = downloader_class_by_key[strategy]
+      klass.preprocess_options(options)
+    end
   end
 end

--- a/lib/cocoapods-downloader/api_exposable.rb
+++ b/lib/cocoapods-downloader/api_exposable.rb
@@ -12,6 +12,9 @@ module Pod
           raise 'Only a module *or* is required, not both.'
         end
         include mod
+        # TODO: Try to find a nicer way to do this
+        # See https://github.com/CocoaPods/cocoapods-downloader/pull/57
+        extend mod
       end
 
       alias override_api expose_api

--- a/lib/cocoapods-downloader/base.rb
+++ b/lib/cocoapods-downloader/base.rb
@@ -154,6 +154,20 @@ module Pod
           execute_command(name.to_s, command.flatten, true)
         end
       end
+
+      # preprocess download options
+      #
+      # Usage of this method is optional. concrete strategies should not
+      # assume options are preprocessed for correct execution.
+      #
+      # @param  [Hash<Symbol,String>] options
+      #         The request options to preprocess
+      #
+      # @return [Hash<Symbol,String>] the new options
+      #
+      def self.preprocess_options(options)
+        options
+      end
     end
   end
 end

--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -28,7 +28,7 @@ module Pod
         command = ['ls-remote',
                    options[:git],
                    options[:branch]]
-        output = Executable.execute_command('git', command)
+        output = Git.execute_command('git', command)
         match = /^([a-z0-9]*)\t.*/.match(output)
 
         return options if match.nil?

--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -22,6 +22,23 @@ module Pod
         end
       end
 
+      def self.preprocess_options(options)
+        return options unless options[:branch]
+
+        command = ['ls-remote',
+                   options[:git],
+                   options[:branch]]
+        output = Executable.execute_command('git', command)
+        match = /^([a-z0-9]*)\t.*/.match(output)
+
+        return options if match.nil?
+
+        options[:commit] = match[1]
+        options.delete(:branch)
+
+        options
+      end
+
       private
 
       # @!group Base class hooks

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -8,6 +8,12 @@ module Pod
         e = lambda { Base.new('path', 'url', options) }.should.raise DownloaderError
         e.message.should.match /Unrecognized options/
       end
+
+      it 'has no preprocessing' do
+        options = { :symbol => 'aaaaaa' }
+        new_options = Base.preprocess_options(options)
+        new_options.should == options
+      end
     end
   end
 end

--- a/spec/bazaar_spec.rb
+++ b/spec/bazaar_spec.rb
@@ -77,6 +77,12 @@ module Pod
         downloader = Downloader.for_target(tmp_folder, options)
         lambda { downloader.download }.should.raise DownloaderError
       end
+
+      it 'has no preprocessing' do
+        options = { :bzr => fixture('bazaar-repo'), :revision => '1' }
+        new_options = Downloader.preprocess_options(options)
+        new_options.should == options
+      end
     end
   end
 end

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -206,16 +206,21 @@ module Pod
 
       describe '::preprocess_options' do
         it 'skips non-branch requests' do
-          options = { :git=> fixture_url('git-repo'), :commit => 'aaaa' }
+          options = { :git => fixture_url('git-repo'), :commit => 'aaaa' }
           new_options = Downloader.preprocess_options(options)
           options.should == new_options
         end
 
-        it 'skips non-branch requests' do
-          puts fixture_url('git-repo')
-          options = { :git=> fixture_url('git-repo'), :branch => 'master' }
+        it 'resolves master to a commit' do
+          options = { :git => fixture_url('git-repo'), :branch => 'master' }
           new_options = Downloader.preprocess_options(options)
           new_options[:commit].should == '98cbf14201a78b56c6b7290f6cac840a7597a1c2'
+        end
+
+        it 'ignores invalid branches' do
+          options = { :git => fixture_url('git-repo'), :branch => 'aaaa' }
+          new_options = Downloader.preprocess_options(options)
+          new_options[:branch].should == 'aaaa'
         end
       end
     end

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -203,6 +203,21 @@ module Pod
           should.not.raise { downloader.download }
         end
       end
+
+      describe '::preprocess_options' do
+        it 'skips non-branch requests' do
+          options = { :git=> fixture_url('git-repo'), :commit => 'aaaa' }
+          new_options = Downloader.preprocess_options(options)
+          options.should == new_options
+        end
+
+        it 'skips non-branch requests' do
+          puts fixture_url('git-repo')
+          options = { :git=> fixture_url('git-repo'), :branch => 'master' }
+          new_options = Downloader.preprocess_options(options)
+          new_options[:commit].should == '98cbf14201a78b56c6b7290f6cac840a7597a1c2'
+        end
+      end
     end
   end
 end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -219,6 +219,12 @@ module Pod
           downloader.send(:type).should == :zip
         end
       end
+
+      it 'has no preprocessing' do
+        options = { :http => 'https://host/file', :type => 'zip' }
+        new_options = Downloader.preprocess_options(options)
+        new_options.should == options
+      end
     end
   end
 end

--- a/spec/mercurial_spec.rb
+++ b/spec/mercurial_spec.rb
@@ -99,6 +99,12 @@ module Pod
           :revision => '61118fa8988c2b2eae826f48abd1e3340dae0c6b',
         }
       end
+
+      it 'has no preprocessing' do
+        options = { :hg => fixture('mercurial-repo'), :tag => '1.0.0' }
+        new_options = Downloader.preprocess_options(options)
+        new_options.should == options
+      end
     end
   end
 end

--- a/spec/subversion_spec.rb
+++ b/spec/subversion_spec.rb
@@ -104,6 +104,16 @@ module Pod
         tmp_folder('README').read.strip.should == 'first commit'
         tmp_folder('.svn').should.exist
       end
+
+      it 'has no preprocessing' do
+        options = {
+          :svn => "file://#{fixture('subversion-repo')}",
+          :revision => '1',
+          :checkout => true,
+        }
+        new_options = Downloader.preprocess_options(options)
+        new_options.should == options
+      end
     end
   end
 end


### PR DESCRIPTION
For now, this is useful only for git when downloading a specific branch.

Related to https://github.com/CocoaPods/CocoaPods/issues/5376.

## TODO
- [x] Add test coverage
- [x] Add to README
- [x] Add to changelog