### PR TITLE
Explicitly checkout submodules when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@
 
 ##### Bug Fixes
 
-* None.  
+* When downloading git submodules, use an explicit command (`git submodules
+  --init --recursive`) instead of relying on the `--recursive` behavior for
+  `git checkout`. This fixes an issue where submodules were checked out using
+  `--depth=1` under git 2.9.  
+  [Gordon Fontenot](https://github.com/gfontenot)
+  [#58](https://github.com/CocoaPods/cocoapods-downloader/pull/58)
+  [CocoaPods#5555](https://github.com/CocoaPods/CocoaPods/issues/5555)
 
 
 ## 1.0.0 (2016-05-10)

--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -79,6 +79,12 @@ module Pod
         ui_sub_action('Git download') do
           begin
             git! clone_arguments(force_head, shallow_clone)
+
+            if options[:submodules]
+              Dir.chdir(target_path) do
+                git! %w(submodule update --init --recursive)
+              end
+            end
           rescue DownloaderError => e
             if e.message =~ /^fatal:.*does not support --depth$/im
               clone(force_head, false)
@@ -113,8 +119,6 @@ module Pod
             command += ['--branch', tag_or_branch]
           end
         end
-
-        command << '--recursive' if options[:submodules]
 
         command
       end


### PR DESCRIPTION
After doing some research, it looks like git 2.9 made a change so that command
line flags are now sent to the submodule commands as well, where pre-2.9
releases ignored those flags for submodules.

That seems like a great change on the surface. But unfortunately for us, it
means that using `--depth=1` and `--recursive` in the same command will almost
always result in a failed clone. This is because the submodule is also
initially checked out using `--depth=1` and so when it then tries to check out
the commit specified by the .gitmodules file, it fails because it doesn't see
that SHA in the git history. The only way it will succeed is if the specified
commit also happens to be the HEAD of master.

This issue can be fixed by removing the `--recursive` flag from the initial
git command, and then running `git submodules --init --recursive` inside the
repo to pull down the submodules.

Fixes CocoaPods/CocoaPods#5555