### PR TITLE
Checkout tags without ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Checkout tags unambiguously when cloning git repos  
+  [Keith Smiley](https://github.com/keith)
+  [#72](https://github.com/CocoaPods/cocoapods-downloader/pull/72)
 
 
 ## 1.1.3 (2016-12-17)

--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -44,6 +44,7 @@ module Pod
       def download!
         clone
         checkout_commit if options[:commit]
+        checkout_tag if options[:tag]
       end
 
       # @return [void] Checks out the HEAD of the git source in the destination
@@ -108,13 +109,13 @@ module Pod
       def clone_arguments(force_head, shallow_clone)
         command = ['clone', url, target_path, '--template=']
 
-        if shallow_clone && !options[:commit]
+        if shallow_clone && !options[:commit] && !options[:tag]
           command += %w(--single-branch --depth 1)
         end
 
         unless force_head
-          if tag_or_branch = options[:tag] || options[:branch]
-            command += ['--branch', tag_or_branch]
+          if branch = options[:branch]
+            command += ['--branch', branch]
           end
         end
 
@@ -125,6 +126,13 @@ module Pod
       #
       def checkout_commit
         target_git 'checkout', '--quiet', options[:commit]
+        update_submodules
+      end
+
+      # Checks out a specific tag of the cloned repo.
+      #
+      def checkout_tag
+        target_git 'checkout', '--quiet', "tags/#{options[:tag]}"
         update_submodules
       end
 

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -137,7 +137,6 @@ module Pod
           downloader.download
 
           tmp_folder('README').read.strip.should == 'v1.0'
-          ensure_only_one_ref(tmp_folder)
         end
 
         it 'clones a specific commit' do


### PR DESCRIPTION
Previously if you had a repo with a branch and a tag with the same name,
using `git clone --branch` would prefer the branch, which may or may not
be the same source as the tag. Now we checkout the tag unambiguously.
The biggest downside here is we no longer do a shallow clone in this
case.