### PR TITLE
[HTTP] Allow curl to retry on transient errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ##### Enhancements
 
-* None.  
+* Allow `curl` to retry HTTP downloads that fail with transient errors.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-downloader/http.rb
+++ b/lib/cocoapods-downloader/http.rb
@@ -8,7 +8,7 @@ module Pod
       executable :curl
 
       def download_file(full_filename)
-        curl! '-f', '-L', '-o', full_filename, url, '--create-dirs', '--netrc-optional'
+        curl! '-f', '-L', '-o', full_filename, url, '--create-dirs', '--netrc-optional', '--retry', '2'
       end
     end
   end


### PR DESCRIPTION
From the `curl` docs:

>               If a transient error is returned when curl tries  to  perform  a
>               transfer,  it  will retry this number of times before giving up.
>               Setting the number to 0 makes curl do no retries (which  is  the
>               default).  Transient  error  means either: a timeout, an FTP 4xx
>               response code or an HTTP 5xx response code.
>
>               When curl is about to retry a transfer, it will first  wait  one
>               second  and  then for all forthcoming retries it will double the
>               waiting time until it reaches 10 minutes which then will be  the
>               delay  between  the rest of the retries.  By using --retry-delay
>               you  disable  this  exponential  backoff  algorithm.  See   also
>               --retry-max-time to limit the total time allowed for retries.
>
>               If this option is used several times, the last one will be used.
>
>               Added in 7.12.3.