### PR TITLE
Adds check for whether directory is actually a bundle before moving children out

### DIFF
--- a/lib/cocoapods-downloader/remote_file.rb
+++ b/lib/cocoapods-downloader/remote_file.rb
@@ -110,7 +110,7 @@ module Pod
           contents = target_path.children
           contents.delete(target_path + @filename)
           entry = contents.first
-          if contents.count == 1 && entry.directory?
+          if contents.count == 1 && entry.directory? && !isBundle?(entry)
             tmp_entry = entry.sub_ext("#{entry.extname}.tmp")
             begin
               FileUtils.move(entry, tmp_entry)
@@ -172,6 +172,20 @@ module Pod
         elsif options[:sha1]
           verify_sha1_hash(filename, options[:sha1])
         end
+      end
+
+      # @note   The entry is a bundle if it is a directory but has a bundle structure
+      #
+      # @return [Bool] Whether the entry is a bundle
+      #
+
+      def isBundle?(entry)
+        isBundle   = File.extname(entry) == '.framework'
+        isBundle ||= File.extname(entry) == '.app'
+        isBundle ||= File.extname(entry) == '.framework'
+        isBundle ||= File.extname(entry) == '.ipa'
+        isBundle ||= File.extname(entry) == '.xcappdata'
+        isBundle
       end
     end
   end


### PR DESCRIPTION
Checks whether post-uncompressed directory is a bundle. If so, do not move the contents out. #84 

I don't know if this is an exhaustive list of extensions for bundles that masquerade as directories, but I wanted to put up at least a first pass at a solution that worked for at least some of them.