### PR TITLE
Add headers option on Http download strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ##### Enhancements
 
-* None.  
+* Add `:headers` option to allow passing in custom headers to `cURL` when downloading source via the `:http` download strategy.  
+  [Wilmar van Heerden](https://github.com/wilmarvh)
+  [cocoapods-downloader#89](https://github.com/CocoaPods/cocoapods-downloader/issues/89)
+  [#557](https://github.com/CocoaPods/Core/pull/557)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods-downloader/http.rb
+++ b/lib/cocoapods-downloader/http.rb
@@ -8,7 +8,14 @@ module Pod
       executable :curl
 
       def download_file(full_filename)
-        curl! '-f', '-L', '-o', full_filename, url, '--create-dirs', '--netrc-optional', '--retry', '2'
+        parameters = ['-f', '-L', '-o', full_filename, url, '--create-dirs', '--netrc-optional', '--retry', '2']
+
+        headers.each do |h|
+          parameters << '-H'
+          parameters << h
+        end unless headers.nil?
+
+        curl! parameters
       end
     end
   end

--- a/lib/cocoapods-downloader/remote_file.rb
+++ b/lib/cocoapods-downloader/remote_file.rb
@@ -6,7 +6,7 @@ module Pod
   module Downloader
     class RemoteFile < Base
       def self.options
-        [:type, :flatten, :sha1, :sha256]
+        [:type, :flatten, :sha1, :sha256, :headers]
       end
 
       class UnsupportedFileTypeError < StandardError; end
@@ -33,6 +33,10 @@ module Pod
         else
           type_with_url(url)
         end
+      end
+
+      def headers
+        options[:headers]
       end
 
       # @note   The archive is flattened if it contains only one folder and its

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -37,6 +37,44 @@ module Pod
         new_options = Downloader.preprocess_options(options)
         new_options.should == options
       end
+
+      it 'passes the correct default parameters to cURL' do
+        options = { :http => "#{@fixtures_url}/lib.zip" }
+        downloader = Downloader.for_target(tmp_folder, options)
+        downloader.expects(:curl!).with(
+          all_of(
+            includes('-f'),
+            includes('-L'),
+            includes('-o'),
+            includes('--create-dirs'),
+            includes('--netrc-optional'),
+            includes('--retry'),
+            includes('2'),
+          ),
+        )
+        should.raise DownloaderError do
+          downloader.download
+        end
+      end
+
+      it 'passes the HTTP headers to cURL' do
+        options = {
+          :http => "#{@fixtures_url}/lib.zip",
+          :headers => ['Accept: application/json', 'Authorization: Bearer'],
+        }
+        downloader = Downloader.for_target(tmp_folder, options)
+        downloader.expects(:curl!).with(
+          all_of(
+            includes('-H'),
+            includes('Accept: application/json'),
+            includes('-H'),
+            includes('Authorization: Bearer'),
+          ),
+        )
+        should.raise DownloaderError do
+          downloader.download
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request adds the ability to add an array of headers onto the `Http` download strategy.

It was created with the goal of being able to download a release binary hosted on Github which requires the `Accept: application/octet-stream` header. However it allows for any headers to be added onto the `curl` command to be being executed.

It is dependant on the following PR to be merged as well: https://github.com/CocoaPods/Core/pull/557

An example of the usage looks as follows:

```
    s.source = {
        :http => "https://api.github.com/repos/my-organization/some-repository/releases/assets/123123", 
        type: :zip,
        :headers => [ "Accept: application/octet-stream" ]
    }
```

It also solves a bit of the frustration raised in https://github.com/CocoaPods/CocoaPods/issues/5055