### PR TITLE
Don't convert branch name to commit hash

### DIFF
--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -21,20 +21,7 @@ module Pod
       end
 
       def self.preprocess_options(options)
-        return options unless options[:branch]
-
-        command = ['ls-remote',
-                   options[:git],
-                   options[:branch]]
-        output = Git.execute_command('git', command)
-        match = /^([a-z0-9]*)\t.*/.match(output)
-
-        return options if match.nil?
-
-        options[:commit] = match[1]
-        options.delete(:branch)
-
-        options
+        return options
       end
 
       private


### PR DESCRIPTION
I'm completely oblivious to rationale for #57, so sorry if this doesn't make any sense.

When a branch name is present, it's replaced by a git hash. This breaks shallow clones (as remarked by @simson2010 https://github.com/CocoaPods/cocoapods-downloader/pull/57#commitcomment-20566222.

It also makes git submodules even more painful, in particular when a branch points to a different origin than master. For example in https://github.com/Sjors/libwally-swift/commits/dev contains a submodule that points to a fork.

This PR removes the conversion from branch name to commit hash.