### PR TITLE
Resolve CI Setup Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: trusty
+os:
+  - osx
 
 language: ruby
 
@@ -21,9 +22,15 @@ before_install:
   # There is a bug in travis. When using system ruby, bundler is not
   # installed and causes the default install action to fail.
   - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem install "bundler:~> 1.15.0"; else gem install "bundler:~> 1.15.0"; fi
-  - sudo apt-get install bzr
+  - rvm pkg install openssl
+  - rvm remove 2.0.0
+  - rvm remove 2.3.4
+  - rvm install 2.0.0 --with-openssl-dir=$HOME/.rvm/usr --binary --fuzzy
+  - rvm install 2.3.4 --with-openssl-dir=$HOME/.rvm/usr --binary --fuzzy
 
 install:
+  - brew update
+  - brew install bzr
   - bundle install
   - git config --global user.name  'CI'
   - git config --global user.email 'CI@example.com'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,21 @@ addons:
  code_climate:
    repo_token: 4d2c1cec2a5ba5fd0cd09aa76d1bcb52854e12ace21660dbf65a36a59ba7a973
 
-rvm:
-  - 2.0.0
-  - 2.3.4
-  - 2.5.0
-  - 2.6.2
+jobs:
+  include:
+  - rvm: 2.0.0
+    osx_image: xcode7.3
+  - rvm: 2.3.4
+    osx_image: xcode7.3
+  - rvm: 2.5.0
+    osx_image: xcode11.5
+  - rvm: 2.6.2
+    osx_image: xcode11.5
 
 before_install:
   # There is a bug in travis. When using system ruby, bundler is not
   # installed and causes the default install action to fail.
   - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem install "bundler:~> 1.15.0"; else gem install "bundler:~> 1.15.0"; fi
-  - rvm pkg install openssl
-  - rvm remove 2.0.0
-  - rvm remove 2.3.4
-  - rvm install 2.0.0 --with-openssl-dir=$HOME/.rvm/usr --binary --fuzzy
-  - rvm install 2.3.4 --with-openssl-dir=$HOME/.rvm/usr --binary --fuzzy
 
 install:
   - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,24 +16,24 @@ jobs:
   include:
   - rvm: 2.0.0
     osx_image: xcode9
-    env: SKIP_XCODE_SELECT=1
   - rvm: 2.3.4
     osx_image: xcode9
-    env: SKIP_XCODE_SELECT=1
   - rvm: 2.5.0
     osx_image: xcode11.5
+    env: INSTALL_SVN=1
   - rvm: 2.6.2
     osx_image: xcode11.5
+    env: INSTALL_SVN=1
 
 before_install:
   # There is a bug in travis. When using system ruby, bundler is not
   # installed and causes the default install action to fail.
   - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem install "bundler:~> 1.15.0"; else gem install "bundler:~> 1.15.0"; fi
-  - "[ -z $SKIP_XCODE_SELECT ] && sudo rm -rf /Library/Developer/CommandLineTools && sudo xcode-select --install"
 
 install:
   - brew update
   - brew install bzr
+  - if [ "$INSTALL_SVN" = "1" ]; then brew install svn; fi
   - bundle install
   - git config --global user.name  'CI'
   - git config --global user.email 'CI@example.com'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,12 @@ before_install:
   # There is a bug in travis. When using system ruby, bundler is not
   # installed and causes the default install action to fail.
   - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem install "bundler:~> 1.15.0"; else gem install "bundler:~> 1.15.0"; fi
+  - sudo rm -rf /Library/Developer/CommandLineTools
+  - sudo xcode-select --install
 
 install:
   - brew update
   - brew install bzr
-  - brew install svn
   - bundle install
   - git config --global user.name  'CI'
   - git config --global user.email 'CI@example.com'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ jobs:
   include:
   - rvm: 2.0.0
     osx_image: xcode9
+    env: SKIP_XCODE_SELECT=1
   - rvm: 2.3.4
     osx_image: xcode9
+    env: SKIP_XCODE_SELECT=1
   - rvm: 2.5.0
     osx_image: xcode11.5
   - rvm: 2.6.2
@@ -27,8 +29,7 @@ before_install:
   # There is a bug in travis. When using system ruby, bundler is not
   # installed and causes the default install action to fail.
   - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem install "bundler:~> 1.15.0"; else gem install "bundler:~> 1.15.0"; fi
-  - sudo rm -rf /Library/Developer/CommandLineTools
-  - sudo xcode-select --install
+  - "[ -z $SKIP_XCODE_SELECT ] && sudo rm -rf /Library/Developer/CommandLineTools && sudo xcode-select --install"
 
 install:
   - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ addons:
 jobs:
   include:
   - rvm: 2.0.0
-    osx_image: xcode7.3
+    osx_image: xcode9
   - rvm: 2.3.4
-    osx_image: xcode7.3
+    osx_image: xcode9
   - rvm: 2.5.0
     osx_image: xcode11.5
   - rvm: 2.6.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 dist: trusty
 
-os:
-  - osx
-
 language: ruby
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   # There is a bug in travis. When using system ruby, bundler is not
   # installed and causes the default install action to fail.
   - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem install "bundler:~> 1.15.0"; else gem install "bundler:~> 1.15.0"; fi
+  - sudo xcode-select --install
 
 install:
   - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,9 @@ before_install:
   # There is a bug in travis. When using system ruby, bundler is not
   # installed and causes the default install action to fail.
   - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem install "bundler:~> 1.15.0"; else gem install "bundler:~> 1.15.0"; fi
+  - sudo apt-get install bzr
 
 install:
-  - brew update
-  - brew install bzr
   - bundle install
   - git config --global user.name  'CI'
   - git config --global user.email 'CI@example.com'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ before_install:
   # There is a bug in travis. When using system ruby, bundler is not
   # installed and causes the default install action to fail.
   - if [ "$TRAVIS_RUBY_VERSION" = "system" ]; then sudo gem install "bundler:~> 1.15.0"; else gem install "bundler:~> 1.15.0"; fi
-  - sudo xcode-select --install
 
 install:
   - brew update
   - brew install bzr
+  - brew install svn
   - bundle install
   - git config --global user.name  'CI'
   - git config --global user.email 'CI@example.com'


### PR DESCRIPTION
From CI runs on PR #96, I noticed failed builds from packages installed by `rvm use` when setting up test runs for ruby-2.0.0-p648 and ruby-2.3.4.

Example failed setup: https://travis-ci.org/github/CocoaPods/cocoapods-downloader/jobs/673912761#L743

I'm not sure if there's a preference regarding running the tests on MacOS or Linux, but there is a linux distribution: `dist: trusty` setting in the config, so I thought I'd try running the tests on linux.

