### PR TITLE
Fix bug of Git shallow cloning is not used when branch is set #106

### DIFF
--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -129,7 +129,7 @@ module Pod
       def clone_arguments(force_head, shallow_clone)
         command = ['clone', url, target_path, '--template=']
 
-        if shallow_clone && !options[:commit]
+        if shallow_clone
           command += %w(--single-branch --depth 1)
         end
 


### PR DESCRIPTION
https://github.com/CocoaPods/cocoapods-downloader/issues/106