### PR TITLE
Fix bug of Git shallow cloning is not used when branch is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   [xdkhan](https://github.com/xdkhan)
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#116](https://github.com/CocoaPods/cocoapods-downloader/pull/116) 
+  
+* Fix bug of Git shallow cloning is not used when branch is set.  
+  [Dimo Hamdy](https://github.com/dimohamdy)
+  [Pavel](https://github.com/paiv)
+  [#106](https://github.com/CocoaPods/cocoapods-downloader/issues/106) 
 
 
 ## 1.4.0 (2020-07-17)

--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -32,7 +32,6 @@ module Pod
         return options if match.nil?
 
         options[:commit] = match
-        options.delete(:branch)
 
         options
       end
@@ -131,6 +130,10 @@ module Pod
         command = ['clone', url, target_path, '--template=']
 
         if shallow_clone && !options[:commit]
+          command += %w(--single-branch --depth 1)
+        end
+
+        if shallow_clone && options[:commit] && options[:branch]
           command += %w(--single-branch --depth 1)
         end
 

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -222,6 +222,30 @@ module Pod
             should.not.raise { downloader.download }
           end
         end
+
+        describe 'get remote default branch if not set branch with shallow clones' do
+          it 'with git <= 2.10.x' do
+            options = { :git => fixture_url('git-repo') }
+            downloader = Downloader.for_target(tmp_folder, options)
+            message = '/usr/local/bin/git clone URL directory --single-branch ' \
+              "--depth 1\nCloning into 'directory'...\n" \
+              'fatal: dumb http transport does not support --depth'
+            dumb_remote_error = Pod::Downloader::DownloaderError.new(message)
+            downloader.stubs(:git!).raises(dumb_remote_error).then.returns(true)
+            should.not.raise { downloader.download }
+          end
+
+          it 'with git >= 2.11.x' do
+            options = { :git => fixture_url('git-repo') }
+            downloader = Downloader.for_target(tmp_folder, options)
+            message = '/usr/local/bin/git clone URL directory --single-branch ' \
+              "--depth 1\nCloning into 'directory'...\n" \
+              'fatal: dumb http transport does not support shallow capabilities'
+            dumb_remote_error = Pod::Downloader::DownloaderError.new(message)
+            downloader.stubs(:git!).raises(dumb_remote_error).then.returns(true)
+            should.not.raise { downloader.download }
+          end
+        end
       end
 
       describe ':commit_from_ls_remote' do


### PR DESCRIPTION
Fix https://github.com/CocoaPods/cocoapods-downloader/issues/106