### PR TITLE
Fix "can't modify frozen string" errors when pods are integrated using the `branch` option (#10920)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Fix "can't modify frozen string" errors when pods are integrated using the `branch` option  
+  [buju77](https://github.com/Buju77)
+  [#10920](https://github.com/CocoaPods/CocoaPods/issues/10920)
 
 ## 1.5.0 (2021-08-31)
 

--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -52,7 +52,7 @@ module Pod
       #
       def self.commit_from_ls_remote(output, branch_name)
         return nil if branch_name.nil?
-        encoded_branch_name = branch_name.force_encoding(Encoding::ASCII_8BIT)
+        encoded_branch_name = branch_name.dup.force_encoding(Encoding::ASCII_8BIT)
         match = %r{([a-z0-9]*)\trefs\/(heads|tags)\/#{Regexp.quote(encoded_branch_name)}}.match(output)
         match[1] unless match.nil?
       end


### PR DESCRIPTION
this PR fixes https://github.com/CocoaPods/CocoaPods/issues/10920