### PR TITLE
Adds a check for command injections in the input for hg and git

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -72,6 +72,10 @@ All CocoaPods development happens on GitHub, there is a repository for [CocoaPod
 
 Follow [@CocoaPods](http://twitter.com/CocoaPods) to get up to date information about what's going on in the CocoaPods world.
 
+## Development
+
+You need to have `svn`, `bzr`, `hg` and `git` installed to run the specs. There are some specs which require `hdiutil` which will only run on macOS.
+
 ## License
 
 This gem and CocoaPods are available under the MIT license.

--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -21,6 +21,7 @@ module Pod
       end
 
       def self.preprocess_options(options)
+        validate_input options
         return options unless options[:branch]
 
         command = ['ls-remote',
@@ -57,7 +58,13 @@ module Pod
         match[1] unless match.nil?
       end
 
-      private_class_method :commit_from_ls_remote
+      def self.validate_input(options)
+        input = [options[:git], options[:branch], options[:commit], options[:tag]]
+        invalid = input.compact.any? { |value| value.start_with?('--') || value.include?(' --') }
+        raise DownloaderError, "Provided unsafe input for git #{options}." if invalid
+      end
+
+      private_class_method :commit_from_ls_remote, :validate_input
 
       private
 

--- a/lib/cocoapods-downloader/mercurial.rb
+++ b/lib/cocoapods-downloader/mercurial.rb
@@ -18,6 +18,19 @@ module Pod
         end
       end
 
+      def self.preprocess_options(options)
+        validate_input options
+        options
+      end
+
+      def self.validate_input(options)
+        input = [options[:hg], options[:revision], options[:branch], options[:tag]].map(&:to_s)
+        invalid = input.compact.any? { |value| value.start_with?('--') || value.include?(' --') }
+        raise DownloaderError, "Provided unsafe input for hg #{options}." if invalid
+      end
+
+      private_class_method :validate_input
+
       private
 
       executable :hg

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -290,6 +290,26 @@ module Pod
           new_options[:branch].should == 'aaaa'
         end
       end
+
+      describe ':bad input' do
+        it 'bails when you provide a bad input' do
+          options = { :git => '--upload-pack=touch ./HELLO1;', :branch => 'foo' }
+          e = lambda { Downloader.preprocess_options(options) }.should.raise DownloaderError
+          e.message.should.match /Provided unsafe input/
+        end
+
+        it 'bails when you provide a bad input after valid input' do
+          options = { :git => 'github.com --upload-pack=touch ./HELLO1;', :branch => 'foo' }
+          e = lambda { Downloader.preprocess_options(options) }.should.raise DownloaderError
+          e.message.should.match /Provided unsafe input/
+        end
+
+        it 'bails with other fields' do
+          options = { :branch => '--upload-pack=touch ./HELLO1;', :git => 'foo' }
+          e = lambda { Downloader.preprocess_options(options) }.should.raise DownloaderError
+          e.message.should.match /Provided unsafe input/
+        end
+      end
     end
   end
 end

--- a/spec/mercurial_spec.rb
+++ b/spec/mercurial_spec.rb
@@ -106,5 +106,13 @@ module Pod
         new_options.should == options
       end
     end
+
+    describe ':bad input' do
+      it 'bails when you provide a bad input' do
+        options = { :hg => '--config=alias.clone=!touch ./HELLO2;' }
+        e = lambda { Downloader.preprocess_options(options) }.should.raise DownloaderError
+        e.message.should.match /Provided unsafe input/
+      end
+    end
   end
 end


### PR DESCRIPTION
It's possible to engineer a string which would cause the hg or git command to run shell commands, this has been blocked up in trunk already (https://github.com/CocoaPods/trunk.cocoapods.org/pull/324) and this fixes it client-side