### PR TITLE
Ensure that the git pre-processor doesn't accidentally bail also

### DIFF
--- a/lib/cocoapods-downloader/git.rb
+++ b/lib/cocoapods-downloader/git.rb
@@ -23,9 +23,15 @@ module Pod
       def self.preprocess_options(options)
         return options unless options[:branch]
 
+        input = [options[:git], options[:commit]].map(&:to_s)
+        invalid = input.compact.any? { |value| value.start_with?('--') || value.include?(' --') }
+        raise DownloaderError, "Provided unsafe input for git #{options}." if invalid
+
         command = ['ls-remote',
+                   '--',
                    options[:git],
                    options[:branch]]
+
         output = Git.execute_command('git', command)
         match = commit_from_ls_remote output, options[:branch]
 

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -289,6 +289,12 @@ module Pod
           new_options = Downloader.preprocess_options(options)
           new_options[:branch].should == 'aaaa'
         end
+
+        it 'throws when proving an invalid input' do
+          options = { :git => '--upload-pack=touch ./HELLO1;', :branch => 'foo' }
+          e = lambda { Downloader.preprocess_options(options) }.should.raise DownloaderError
+          e.message.should.match /Provided unsafe input/
+        end
       end
 
       describe ':bad input' do


### PR DESCRIPTION
The refactor in #127 moved everything into the `download` path (as all API consumers would have to use that eventually) but `self.preprocess_options` can get called before that (and independently of it) and so this handles that case.