### PR TITLE
fix: Ignore default curl config file

### DIFF
--- a/lib/cocoapods-downloader/http.rb
+++ b/lib/cocoapods-downloader/http.rb
@@ -10,7 +10,7 @@ module Pod
       executable :curl
 
       def download_file(full_filename)
-        parameters = ['-f', '-L', '-o', full_filename, url, '--create-dirs', '--netrc-optional', '--retry', '2']
+        parameters = ['--disable', '-f', '-L', '-o', full_filename, url, '--create-dirs', '--netrc-optional', '--retry', '2']
         parameters << user_agent_argument if headers.nil? ||
             headers.none? { |header| header.casecmp(USER_AGENT_HEADER).zero? }
 


### PR DESCRIPTION
A user-provided config file may add parameters that are incompatible with those supplied by CocoaPods. This causes the download to fail.

This change causes curl to behave as if no default config file exists, which allows for more consistent behavior.

This closes #130.